### PR TITLE
fix for supporting Chinese character

### DIFF
--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -1156,7 +1156,7 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
     
     selectedNSRange = NSMakeRange(selectedRange.location + markedTextRange.location, selectedRange.length);
     
-    self.attributedString = _attributedString;
+    self.attributedString = markedText.length == 0 ? _attributedString : _mutableAttributedString;
     self.markedRange = markedTextRange;
     self.selectedRange = selectedNSRange;    
     


### PR DESCRIPTION
`setMarkedText` seemed to set `attributedString` to itself, and `_mutableAttributedString` was changed but never set.
