### PR TITLE
Handle deletion of composed character sequences (e.g., Emoji)

### DIFF
--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -1473,9 +1473,8 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
             [self performSelector:@selector(showCorrectionMenuWithoutSelection) withObject:nil afterDelay:0.2f];
         }
         
-        selectedNSRange.location--;
-        selectedNSRange.length = 1;
-        
+        selectedNSRange = [[_attributedString string] rangeOfComposedCharacterSequenceAtIndex:selectedNSRange.location - 1];
+      
         [_mutableAttributedString beginEditing];
         [_mutableAttributedString deleteCharactersInRange:selectedNSRange];
         [_mutableAttributedString endEditing];


### PR DESCRIPTION
This fixes the `deleteBackward` method to correctly delete multi-byte characters, such as Emoji.

Signed-off-by: Chris Brauchli cbrauchli@gmail.com
