### PR TITLE
Handle non-zero frame origin and selection position onChange

### DIFF
--- a/EGOTextView/EGOTextView.h
+++ b/EGOTextView/EGOTextView.h
@@ -124,5 +124,6 @@ extern NSString * const EGOTextAttachmentPlaceholderString;
 @property(nonatomic) NSRange markedRange;
 
 - (BOOL)hasText;
+- (void)tap:(UITapGestureRecognizer*)gesture;
 
 @end

--- a/EGOTextView/EGOTextView.h
+++ b/EGOTextView/EGOTextView.h
@@ -47,6 +47,8 @@ extern NSString * const EGOTextAttachmentPlaceholderString;
 
 - (void)egoTextView:(EGOTextView*)textView didSelectURL:(NSURL*)URL;
 
+- (void)egoTextViewTouched:(EGOTextView*)textView;
+
 @end
 
 @protocol EGOTextAttachmentCell <NSObject>
@@ -79,6 +81,7 @@ extern NSString * const EGOTextAttachmentPlaceholderString;
     BOOL _delegateRespondsToDidChange;
     BOOL _delegateRespondsToDidChangeSelection;
     BOOL _delegateRespondsToDidSelectURL;
+    BOOL _delegateRespondsToTouched;
     
     NSAttributedString  *_attributedString;
     UIFont              *_font; 

--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -1419,10 +1419,11 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
     
     [newString release];
     
-    self.attributedString = _mutableAttributedString;
     self.markedRange = markedTextRange;
-    self.selectedRange = selectedNSRange;  
-        
+    _selectedRange = selectedNSRange;
+    self.attributedString = _mutableAttributedString;
+    [self selectionChanged];
+    
     if (text.length > 1 || ([text isEqualToString:@" "] || [text isEqualToString:@"\n"])) {
         [self checkSpellingForRange:[self characterRangeAtIndex:self.selectedRange.location-1]];
         [self checkLinksForRange:NSMakeRange(0, self.attributedString.length)];
@@ -1484,9 +1485,10 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
         
     }
     
-    self.attributedString = _mutableAttributedString;
     self.markedRange = markedTextRange;
-    self.selectedRange = selectedNSRange; 
+    _selectedRange = selectedNSRange;
+    self.attributedString = _mutableAttributedString;
+    [self selectionChanged];
     
 }
 

--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -1486,6 +1486,10 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
     }
     
     self.markedRange = markedTextRange;
+    if(selectedNSRange.location > _mutableAttributedString.length) {
+        selectedNSRange.location = _mutableAttributedString.length;
+        selectedNSRange.length = 0;
+    }
     _selectedRange = selectedNSRange;
     self.attributedString = _mutableAttributedString;
     [self selectionChanged];

--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -1871,13 +1871,13 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
         
     } else {
         
-        if (index==self.selectedRange.location) {
-            [self performSelector:@selector(showMenu) withObject:nil afterDelay:0.35f];
-        } else {
-            if (_editing) {
-                [self performSelector:@selector(showCorrectionMenu) withObject:nil afterDelay:0.35f];
-            }
-        }
+//        if (index==self.selectedRange.location) {
+//            [self performSelector:@selector(showMenu) withObject:nil afterDelay:0.35f];
+//        } else {
+//            if (_editing) {
+//                [self performSelector:@selector(showCorrectionMenu) withObject:nil afterDelay:0.35f];
+//            }
+//        }
         
     }
     

--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -1856,7 +1856,12 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
         self.selectedRange = NSMakeRange(_selectedRange.location, 0);
     }
     
-    NSInteger index = [self closestWhiteSpaceIndexToPoint:[gesture locationInView:self]];
+    NSInteger index;
+    if(gesture) {
+        index = [self closestWhiteSpaceIndexToPoint:[gesture locationInView:self]];
+    } else {
+        index = 0;
+    }
     
     if (_delegateRespondsToDidSelectURL && !_editing) {
         if ([self selectedLinkAtIndex:index]) {

--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -969,6 +969,9 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
         [_textContentView setNeedsDisplay];
     }
     
+    if(_delegateRespondsToDidChangeSelection) {
+        [self.delegate egoTextViewDidChangeSelection:self];
+    }
 }
 
 - (NSRange)markedRange {

--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -1764,7 +1764,7 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
         } else {
             
             CGPoint location = [gesture locationInView:_textWindow];
-            CGRect rect = CGRectMake(location.x, location.y, _caretView.bounds.size.width, _caretView.bounds.size.height);
+            CGRect rect = CGRectMake(location.x + self.frame.origin.x, location.y - self.frame.origin.y, _caretView.bounds.size.width, _caretView.bounds.size.height);
             
             self.selectedRange = NSMakeRange(index, 0);
             
@@ -2507,8 +2507,8 @@ static const NSTimeInterval kDefaultAnimationDuration = 0.15f;
         }
                         
         CGRect frame = _view.frame;
-        frame.origin.x = floorf(pos.x - (_view.bounds.size.width/2));
-        frame.origin.y = floorf(pos.y - _view.bounds.size.height);
+        frame.origin.x = floorf(pos.x - (_view.bounds.size.width/2) - view.superview.frame.origin.x);
+        frame.origin.y = floorf(pos.y - _view.bounds.size.height + view.superview.frame.origin.y);
         
         if (_type==EGOWindowMagnify) {
             
@@ -2643,8 +2643,8 @@ static const NSTimeInterval kDefaultAnimationDuration = 0.15f;
     if (_showing && _view!=nil) {
         
         CGRect frame = _view.frame;
-        frame.origin.x = floorf((pos.x - (_view.bounds.size.width/2)) + (rect.size.width/2));
-        frame.origin.y = floorf(pos.y - _view.bounds.size.height);
+        frame.origin.x = floorf((pos.x - (_view.bounds.size.width/2)) + (rect.size.width/2) - view.superview.frame.origin.x);
+        frame.origin.y = floorf(pos.y - _view.bounds.size.height + view.superview.frame.origin.y);
 
         if (_type==EGOWindowMagnify) {
             frame.origin.y = MAX(0.0f, frame.origin.y);

--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -413,6 +413,7 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
     _delegateRespondsToDidChange = [delegate respondsToSelector:@selector(egoTextViewDidChange:)];
     _delegateRespondsToDidChangeSelection = [delegate respondsToSelector:@selector(egoTextViewDidChangeSelection:)];
     _delegateRespondsToDidSelectURL = [delegate respondsToSelector:@selector(egoTextView:didSelectURL:)];
+    _delegateRespondsToTouched = [delegate respondsToSelector:@selector(egoTextViewTouched:)];
     
 }
 
@@ -1701,6 +1702,10 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
 }
 
 - (void)longPress:(UILongPressGestureRecognizer*)gesture {
+    if(_delegateRespondsToTouched) {
+        [self.delegate egoTextViewTouched:self];
+    }
+
 
     if (gesture.state==UIGestureRecognizerStateBegan || gesture.state == UIGestureRecognizerStateChanged) {
         
@@ -1810,6 +1815,10 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
 }
 
 - (void)doubleTap:(UITapGestureRecognizer*)gesture {
+    if(_delegateRespondsToTouched) {
+        [self.delegate egoTextViewTouched:self];
+    }
+
     
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(showMenu) object:nil];
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(showCorrectionMenu) object:nil];
@@ -1830,7 +1839,10 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
 }
 
 - (void)tap:(UITapGestureRecognizer*)gesture {
-        
+    if(_delegateRespondsToTouched) {
+        [self.delegate egoTextViewTouched:self];
+    }    
+    
     if (_editable && ![self isFirstResponder]) {
         [self becomeFirstResponder];  
         return;
@@ -1876,6 +1888,13 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
     
     [self.inputDelegate selectionDidChange:self];
     
+}
+
+-(void) touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
+    if(_delegateRespondsToTouched) {
+        [self.delegate egoTextViewTouched:self];
+    }
+    [super touchesBegan:touches withEvent:event];
 }
 
 

--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -1861,6 +1861,10 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
         index = [self closestWhiteSpaceIndexToPoint:[gesture locationInView:self]];
     } else {
         index = 0;
+        self.markedRange = NSMakeRange(0, 0);
+        self.selectedRange = NSMakeRange(index, 0);
+        return;
+
     }
     
     if (_delegateRespondsToDidSelectURL && !_editing) {

--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -1888,11 +1888,7 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
     
     [self.inputDelegate selectionWillChange:self];
     
-    if(gesture) {
-        self.markedRange = NSMakeRange(NSNotFound, 0);
-    } else {
-        self.markedRange = NSMakeRange(0, 0);
-    }
+    self.markedRange = NSMakeRange(NSNotFound, 0);
     self.selectedRange = NSMakeRange(index, 0);
     
     [self.inputDelegate selectionDidChange:self];

--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -1888,7 +1888,11 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
     
     [self.inputDelegate selectionWillChange:self];
     
-    self.markedRange = NSMakeRange(NSNotFound, 0);
+    if(gesture) {
+        self.markedRange = NSMakeRange(NSNotFound, 0);
+    } else {
+        self.markedRange = NSMakeRange(0, 0);
+    }
     self.selectedRange = NSMakeRange(index, 0);
     
     [self.inputDelegate selectionDidChange:self];

--- a/EGOTextView/EGOTextView.m
+++ b/EGOTextView/EGOTextView.m
@@ -1861,10 +1861,6 @@ static CGFloat AttachmentRunDelegateGetWidth(void *refCon) {
         index = [self closestWhiteSpaceIndexToPoint:[gesture locationInView:self]];
     } else {
         index = 0;
-        self.markedRange = NSMakeRange(0, 0);
-        self.selectedRange = NSMakeRange(index, 0);
-        return;
-
     }
     
     if (_delegateRespondsToDidSelectURL && !_editing) {

--- a/EGOTextView_Demo/EGOTextView_DemoViewController.m
+++ b/EGOTextView_Demo/EGOTextView_DemoViewController.m
@@ -107,6 +107,10 @@
     NSLog(@"%s", __PRETTY_FUNCTION__);
 }
 
+- (void)egoTextViewTouched:(EGOTextView*)textView {
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+}
+
 - (void)egoTextView:(EGOTextView*)textView didSelectURL:(NSURL *)URL {
         
 }

--- a/EGOTextView_Demo/EGOTextView_DemoViewController.m
+++ b/EGOTextView_Demo/EGOTextView_DemoViewController.m
@@ -103,6 +103,10 @@
 
 }
 
+- (void)egoTextViewDidChangeSelection:(EGOTextView*)textView {
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+}
+
 - (void)egoTextView:(EGOTextView*)textView didSelectURL:(NSURL *)URL {
         
 }


### PR DESCRIPTION
In my application the EGOTextView is offset from the left edge of the screen.  This was causing alignment issues with the magnifier, which I've fixed here.  I tested this in the demo application by creating the EGOTextView with a frame with origin.x and origin.y set to positive non-zero values.

Before:
![EGOTextView-weathermob-before](https://f.cloud.github.com/assets/72315/33968/8720f8d6-50e5-11e2-865e-765147dda1ee.png)

After:
![EGOTextView-weathermob-after](https://f.cloud.github.com/assets/72315/33969/921ee568-50e5-11e2-84d8-8fe0a78fd8e1.png)

In addition, when the text field was edited, the selection information (_selectedRange) was being updated after the attributedString was set.  This caused the selection position as monitored in the delegate -egoTextViewDidChange: method to always lag by one character.  In -insertText: and -deleteBackward I'm not calling the two steps from -setSelectionRange separately, as the range needs to be set before -setAttributedString: calls the delegate function, but -selectionChanged needs to be called after the string is set.  Maybe not the most elegant solution, but it works.
